### PR TITLE
Added feature to handle links timing out

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,7 @@ The tool can check multiple URLs or HTML files to be checked at once if more tha
 But url and html cannot be mixed together in a single command.<br/>
 The -u option is still required when checking multiple URLs.<br/>
 <br>
-Handles Unix and windows style of args -u or /u
+Handles Unix and windows style of args -u or /u<br/>
+<br>
+Handles links that cause timeouts smoothly
 

--- a/src/main.js
+++ b/src/main.js
@@ -27,13 +27,20 @@ function linkCheck(file) {
     urls.map(url => {
         fetch(url)
             .then(res => {
-                if (res.status == 200) {
-                    console.log(chalk.green(url))
-                } else if (res.status == 400 || res.status == 404) {
-                    console.log(chalk.red(url))
+                if (res.ok) {                
+                    if (res.status == 200) {
+                        console.log(chalk.green(url));
+                    } else if (res.status == 400 || res.status == 404) {
+                        console.log(chalk.red(url));
+                    } else {
+                        console.log(chalk.grey(url));
+                    }
                 } else {
-                    console.log(chalk.grey(url))
+                    throw new Error('Poor network response');
                 }
+            })
+            .catch(error => {
+                console.log(chalk.red(url));
             });
     })
 }
@@ -50,9 +57,17 @@ export function cli(args) {
     } else if (parsedArgs.url) {
         parsedArgs.inputArg.map(url => {
             fetch(url)
-                .then(res => res.text())
+                .then(res => {
+                    if (!res.ok){
+                        throw new Error('Poor network response');
+                    }
+                    return res.text();
+                })
                 .then(body => linkCheck(body))
-                .catch(() => console.log(chalk.bgRed("Invalid url, absolute URL only")));
+                .catch((error) => {
+                    console.error('Fetch operation failed', error);
+                    console.log(chalk.bgRed("Invalid url, absolute URL only"));
+                });
         })
     } else {
         parsedArgs.inputArg.map(file => {


### PR DESCRIPTION
Fixes #4 

Introduced error checking within the 'linkCheck()' function. Rather than accessing the response status immediately, the program now checks to see if the response was 'ok'. If it was not a good response, an error gets thrown and handled now.

Tested against http://www.deadlinkcity.com/, links no longer cause the program to crash.